### PR TITLE
Single payment password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,3 @@ typings/
 
 # dotenv environment variables file
 .env
-
-lib/

--- a/flow-typed/types.js
+++ b/flow-typed/types.js
@@ -15,29 +15,35 @@ declare type ScryptParams = {|
 |}
 
 declare type PasswordOptions = {|
-  scryptParams: ScryptParams,
-  salt: string,
-  encryptionType: string,
+  +scryptParams: ScryptParams,
+  +salt: string,
+  +passwordHint: string,
+  +encryptionType: string,
+  +saltBytesCount: number,
+  +derivedKeyLength: number,
 |}
 
 declare type MnemonicOptions = {|
-  network: Network,
-  passphrase: string,
-  derivationPath: string,
-  paddedMnemonicLength: number,
+  +network: Network,
+  +passphrase: string,
+  +derivationPath: string,
+  +paddedMnemonicLength: number,
 |}
 
 declare type PasswordOptionsUser = {|
-  scryptParams?: ScryptParams,
-  salt?: string,
-  encryptionType?: string,
+  +scryptParams?: ScryptParams,
+  +salt?: string,
+  +passwordHint?: string,
+  +encryptionType?: string,
+  +saltBytesCount?: number,
+  +derivedKeyLength?: number,
 |}
 
 declare type MnemonicOptionsUser = {|
-  network?: Network,
-  passphrase?: string,
-  derivationPath?: string,
-  paddedMnemonicLength?: number,
+  +network?: Network,
+  +passphrase?: string,
+  +derivationPath?: string,
+  +paddedMnemonicLength?: number,
 |}
 
 declare type PasswordResult = {|

--- a/flow-typed/types.js
+++ b/flow-typed/types.js
@@ -3,17 +3,9 @@ declare type Addresses = Array<Address>
 
 declare type Network = string | number
 
-declare type WalletType = 'address' | 'mnemonic'
-declare type WalletCustomType = WalletType | 'bip32Xpub' | 'privateKey'
-
 type EncryptedData = {|
   +data: string,
   +nonce: string,
-|}
-
-declare type WalletEncryptedData = {|
-  +mnemonic: ?EncryptedData,
-  +privateKey: ?EncryptedData,
 |}
 
 declare type ScryptParams = {|
@@ -47,71 +39,6 @@ declare type MnemonicOptionsUser = {|
   passphrase?: string,
   derivationPath?: string,
   paddedMnemonicLength?: number,
-|}
-
-declare type Wallet = {|
-  +passwordOptions: ?PasswordOptions,
-  +mnemonicOptions: ?MnemonicOptions,
-  +encrypted: WalletEncryptedData,
-  +id: string,
-  +name: string,
-  +type: WalletType,
-  +address: ?string,
-  +bip32XPublicKey: ?string,
-  +customType: WalletCustomType,
-  +addressIndex: ?number,
-  +isReadOnly: boolean,
-|}
-
-declare type WalletUpdatedData = {|
-  +passwordOptions?: PasswordOptions,
-  +mnemonicOptions?: MnemonicOptions,
-  +encrypted?: WalletEncryptedData,
-  +name?: string,
-  +bip32XPublicKey?: ?string,
-  +customType?: ?WalletCustomType,
-  +addressIndex?: ?number,
-  +isReadOnly?: ?boolean,
-|}
-
-declare type WalletNewData = {|
-  +scryptParams?: ScryptParams,
-  +data: string,
-  +name?: string,
-  +network?: Network,
-  +passphrase?: string,
-  +derivationPath?: string,
-  +encryptionType?: string,
-  +saltBytesCount?: number,
-  +derivedKeyLength?: number,
-  +paddedMnemonicLength?: number,
-|}
-
-declare type WalletData = {|
-  +passwordOptions: PasswordOptions,
-  +mnemonicOptions: MnemonicOptions,
-  +id: string,
-  +data: string,
-  +name: string,
-|}
-
-declare type WalletDecryptedData = {|
-  +id: string,
-  +name: string,
-  +address: string,
-  +mnemonic: string,
-  +privateKey: string,
-  +type: WalletCustomType,
-  +readOnly: 'yes' | 'no',
-  +bip32XPublicKey: string,
-|}
-
-declare type Wallets = Array<Wallet>
-
-declare type Keystore = {|
-  +wallets: Wallets,
-  +testPasswordData: EncryptedData,
-  +passwordOptions: PasswordOptions,
 |}
 
 declare type PasswordResult = {|

--- a/flow-typed/types.js
+++ b/flow-typed/types.js
@@ -17,7 +17,6 @@ declare type ScryptParams = {|
 declare type PasswordOptions = {|
   scryptParams: ScryptParams,
   salt: string,
-  passwordHint: ?string,
   encryptionType: string,
 |}
 
@@ -30,7 +29,6 @@ declare type MnemonicOptions = {|
 
 declare type PasswordOptionsUser = {|
   scryptParams?: ScryptParams,
-  passwordHint?: string,
   encryptionType?: string,
 |}
 

--- a/flow-typed/types.js
+++ b/flow-typed/types.js
@@ -1,7 +1,7 @@
 declare type Address = string
 declare type Addresses = Array<Address>
 
-declare type Network = string | number | void
+declare type Network = string | number
 
 declare type WalletType = 'address' | 'mnemonic'
 declare type WalletCustomType = WalletType | 'bip32Xpub' | 'privateKey'
@@ -25,9 +25,8 @@ declare type ScryptParams = {|
 declare type PasswordOptions = {|
   scryptParams: ScryptParams,
   salt: string,
+  passwordHint: ?string,
   encryptionType: string,
-  saltBytesCount: number,
-  derivedKeyLength: number,
 |}
 
 declare type MnemonicOptions = {|
@@ -35,6 +34,19 @@ declare type MnemonicOptions = {|
   passphrase: string,
   derivationPath: string,
   paddedMnemonicLength: number,
+|}
+
+declare type PasswordOptionsUser = {|
+  scryptParams?: ScryptParams,
+  passwordHint?: string,
+  encryptionType?: string,
+|}
+
+declare type MnemonicOptionsUser = {|
+  network?: Network,
+  passphrase?: string,
+  derivationPath?: string,
+  paddedMnemonicLength?: number,
 |}
 
 declare type Wallet = {|
@@ -96,9 +108,10 @@ declare type WalletDecryptedData = {|
 
 declare type Wallets = Array<Wallet>
 
-declare type Backup = {|
-  +version: string,
-  +wallets?: ?Wallets,
+declare type Keystore = {|
+  +wallets: Wallets,
+  +testPasswordData: EncryptedData,
+  +passwordOptions: PasswordOptions,
 |}
 
 declare type PasswordResult = {|

--- a/flow-typed/types.js
+++ b/flow-typed/types.js
@@ -29,6 +29,7 @@ declare type MnemonicOptions = {|
 
 declare type PasswordOptionsUser = {|
   scryptParams?: ScryptParams,
+  salt?: string,
   encryptionType?: string,
 |}
 

--- a/lib/encryption.js
+++ b/lib/encryption.js
@@ -1,0 +1,98 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.encryptData = encryptData;
+exports.decryptData = decryptData;
+
+var _tweetnacl = require('tweetnacl');
+
+var _tweetnacl2 = _interopRequireDefault(_tweetnacl);
+
+var _tweetnaclUtil = require('tweetnacl-util');
+
+var _tweetnaclUtil2 = _interopRequireDefault(_tweetnaclUtil);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function getNonce(nonceLength) {
+  return _tweetnacl2.default.randomBytes(nonceLength);
+}
+
+function decodePrivateKey(privateKey) {
+  var privateKeyBase = Buffer.from(privateKey).toString('base64');
+
+  return _tweetnaclUtil2.default.decodeBase64(privateKeyBase);
+}
+
+function encodeEncryptedData(encryptedData, nonce) {
+  return {
+    nonce: _tweetnaclUtil2.default.encodeBase64(nonce),
+    data: _tweetnaclUtil2.default.encodeBase64(encryptedData)
+  };
+}
+
+function encryptNaclSecretbox(data, derivedKey, isPrivateKey) {
+  var nonce = getNonce(_tweetnacl2.default.secretbox.nonceLength);
+  var dataToEncrypt = isPrivateKey ? decodePrivateKey(data) : _tweetnaclUtil2.default.decodeUTF8(data);
+  var encryptedData = _tweetnacl2.default.secretbox(dataToEncrypt, nonce, derivedKey);
+
+  if (encryptedData === null || encryptedData === undefined) {
+    throw new Error('Password is invalid');
+  }
+
+  return encodeEncryptedData(encryptedData, nonce);
+}
+
+function encryptData(payload) {
+  var data = payload.data,
+      derivedKey = payload.derivedKey,
+      encryptionType = payload.encryptionType,
+      isPrivateKey = payload.isPrivateKey;
+
+
+  if (encryptionType !== 'nacl.secretbox') {
+    throw new Error('Encryption type ' + encryptionType + ' is not supported');
+  }
+
+  return encryptNaclSecretbox(data, derivedKey, isPrivateKey);
+}
+
+function decodeEncryptedData(data) {
+  return {
+    data: _tweetnaclUtil2.default.decodeBase64(data.data),
+    nonce: _tweetnaclUtil2.default.decodeBase64(data.nonce)
+  };
+}
+
+function encodePrivateKey(privateKey) {
+  var privateKeyBase = _tweetnaclUtil2.default.encodeBase64(privateKey);
+
+  return Buffer.from(privateKeyBase, 'base64').toString();
+}
+
+function decryptNaclSecretbox(data, derivedKey, isPrivateKey) {
+  var decoded = decodeEncryptedData(data);
+  var decryptedData = _tweetnacl2.default.secretbox.open(decoded.data, decoded.nonce, derivedKey);
+
+  if (decryptedData === null || decryptedData === undefined) {
+    throw new Error('Password is invalid');
+  }
+
+  return isPrivateKey ? encodePrivateKey(decryptedData) : _tweetnaclUtil2.default.encodeUTF8(decryptedData);
+}
+
+function decryptData(payload) {
+  var data = payload.data,
+      derivedKey = payload.derivedKey,
+      encryptionType = payload.encryptionType,
+      isPrivateKey = payload.isPrivateKey;
+
+
+  if (encryptionType !== 'nacl.secretbox') {
+    throw new Error('Decryption type ' + encryptionType + ' is not supported');
+  }
+
+  return decryptNaclSecretbox(data, derivedKey, isPrivateKey);
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _keystore = require('./keystore');
+
+var keystore = _interopRequireWildcard(_keystore);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+exports.default = keystore;

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -86,7 +86,7 @@ function getPasswordOptions(options) {
     scryptParams: DEFAULT_SCRYPT_PARAMS,
     encryptionType: DEFAULT_ENCRYPTION_TYPE
   } : {
-    salt: salt,
+    salt: options.salt || salt,
     scryptParams: options.scryptParams || DEFAULT_SCRYPT_PARAMS,
     encryptionType: options.encryptionType || DEFAULT_ENCRYPTION_TYPE
   };

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -5,6 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.checkBip32XPublicKeyValid = exports.checkMnemonicValid = exports.generateMnemonic = exports.testPassword = undefined;
 exports.generateSalt = generateSalt;
+exports.leftPadString = leftPadString;
 exports.getPasswordOptions = getPasswordOptions;
 exports.getMnemonicOptions = getMnemonicOptions;
 exports.getHdPath = getHdPath;
@@ -71,6 +72,10 @@ exports.checkMnemonicValid = _mnemonic.checkMnemonicValid;
 exports.checkBip32XPublicKeyValid = _mnemonic.checkBip32XPublicKeyValid;
 function generateSalt(byteCount) {
   return utils.generateSalt(byteCount);
+}
+
+function leftPadString(stringToPad, padChar, totalLength) {
+  return utils.leftPadString(stringToPad, padChar, totalLength);
 }
 
 function getPasswordOptions(options) {
@@ -181,7 +186,7 @@ function getXPubFromMnemonic(mnemonic, mnemonicOptionsUser) {
 }
 
 function encryptMnemonic(mnemonic, password, passwordOptionsUser) {
-  var mnemonicPad = utils.leftPadString(mnemonic, ' ', PADDED_MNEMONIC_LENGTH);
+  var mnemonicPad = leftPadString(mnemonic, ' ', PADDED_MNEMONIC_LENGTH);
   var passwordOptions = getPasswordOptions(passwordOptionsUser);
 
   var salt = passwordOptions.salt,

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -83,12 +83,10 @@ function getPasswordOptions(options) {
 
   return !options ? {
     salt: salt,
-    passwordHint: null,
     scryptParams: DEFAULT_SCRYPT_PARAMS,
     encryptionType: DEFAULT_ENCRYPTION_TYPE
   } : {
     salt: salt,
-    passwordHint: options.passwordHint,
     scryptParams: options.scryptParams || DEFAULT_SCRYPT_PARAMS,
     encryptionType: options.encryptionType || DEFAULT_ENCRYPTION_TYPE
   };

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.checkBip32XPublicKeyValid = exports.checkMnemonicValid = exports.generateMnemonic = exports.testPassword = undefined;
 exports.generateSalt = generateSalt;
 exports.getChecksum = getChecksum;
+exports.add0x = add0x;
 exports.leftPadString = leftPadString;
 exports.getPasswordOptions = getPasswordOptions;
 exports.getMnemonicOptions = getMnemonicOptions;
@@ -77,6 +78,10 @@ function generateSalt(byteCount) {
 
 function getChecksum(address) {
   return utils.getChecksum(address);
+}
+
+function add0x(data) {
+  return utils.add0x(data);
 }
 
 function leftPadString(stringToPad, padChar, totalLength) {

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -1,0 +1,256 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.checkBip32XPublicKeyValid = exports.checkMnemonicValid = exports.generateMnemonic = exports.testPassword = undefined;
+exports.getPasswordOptions = getPasswordOptions;
+exports.getMnemonicOptions = getMnemonicOptions;
+exports.getHdPath = getHdPath;
+exports.getPrivateHdRoot = getPrivateHdRoot;
+exports.getPublicHdRoot = getPublicHdRoot;
+exports.deriveKeyFromPassword = deriveKeyFromPassword;
+exports.encryptData = encryptData;
+exports.decryptData = decryptData;
+exports.checkAddressValid = checkAddressValid;
+exports.checkChecksumAddressValid = checkChecksumAddressValid;
+exports.checkPrivateKeyValid = checkPrivateKeyValid;
+exports.checkDerivationPathValid = checkDerivationPathValid;
+exports.checkWalletIsNotReadOnly = checkWalletIsNotReadOnly;
+exports.getAddressFromPrivateKey = getAddressFromPrivateKey;
+exports.getXPubFromMnemonic = getXPubFromMnemonic;
+exports.encryptMnemonic = encryptMnemonic;
+exports.encryptPrivateKey = encryptPrivateKey;
+exports.decryptMnemonic = decryptMnemonic;
+exports.decryptPrivateKey = decryptPrivateKey;
+exports.getPrivateKeyFromMnemonic = getPrivateKeyFromMnemonic;
+exports.generateAddress = generateAddress;
+exports.generateAddresses = generateAddresses;
+
+var _bitcoreLib = require('bitcore-lib');
+
+var _bitcoreLib2 = _interopRequireDefault(_bitcoreLib);
+
+var _bitcoreMnemonic = require('bitcore-mnemonic');
+
+var _bitcoreMnemonic2 = _interopRequireDefault(_bitcoreMnemonic);
+
+var _password = require('./password');
+
+var _mnemonic = require('./mnemonic');
+
+var _utils = require('./utils');
+
+var utils = _interopRequireWildcard(_utils);
+
+var _encryption = require('./encryption');
+
+var encryption = _interopRequireWildcard(_encryption);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var DEFAULT_SCRYPT_PARAMS = {
+  N: Math.pow(2, 18),
+  r: 8,
+  p: 1
+};
+
+var DEFAULT_NETWORK = 'livenet';
+var DEFAULT_ENCRYPTION_TYPE = 'nacl.secretbox';
+var DEFAULT_DERIVATION_PATH = 'm/44\'/60\'/0\'/0';
+var PADDED_MNEMONIC_LENGTH = 120;
+var DEFAULT_SALT_BYTES_COUNT = 32;
+var DEFAULT_DERIVATION_KEY_LENGTH = 32;
+
+exports.testPassword = _password.testPassword;
+exports.generateMnemonic = _mnemonic.generateMnemonic;
+exports.checkMnemonicValid = _mnemonic.checkMnemonicValid;
+exports.checkBip32XPublicKeyValid = _mnemonic.checkBip32XPublicKeyValid;
+function getPasswordOptions(options) {
+  var salt = utils.generateSalt(DEFAULT_SALT_BYTES_COUNT);
+
+  return !options ? {
+    salt: salt,
+    passwordHint: null,
+    scryptParams: DEFAULT_SCRYPT_PARAMS,
+    encryptionType: DEFAULT_ENCRYPTION_TYPE
+  } : {
+    salt: salt,
+    passwordHint: options.passwordHint,
+    scryptParams: options.scryptParams || DEFAULT_SCRYPT_PARAMS,
+    encryptionType: options.encryptionType || DEFAULT_ENCRYPTION_TYPE
+  };
+}
+
+function getMnemonicOptions(options) {
+  return !options ? {
+    passphrase: '',
+    network: DEFAULT_NETWORK,
+    derivationPath: DEFAULT_DERIVATION_PATH,
+    paddedMnemonicLength: PADDED_MNEMONIC_LENGTH
+  } : {
+    passphrase: options.passphrase || '',
+    network: options.network || DEFAULT_NETWORK,
+    derivationPath: options.derivationPath || DEFAULT_DERIVATION_PATH,
+    paddedMnemonicLength: options.paddedMnemonicLength || PADDED_MNEMONIC_LENGTH
+  };
+}
+
+function getHdPath(mnemonic, mnemonicOptions) {
+  var network = mnemonicOptions.network,
+      passphrase = mnemonicOptions.passphrase,
+      derivationPath = mnemonicOptions.derivationPath;
+
+
+  var hdRoot = new _bitcoreMnemonic2.default(mnemonic.trim()).toHDPrivateKey(passphrase, network).xprivkey;
+  var hdRootKey = new _bitcoreLib2.default.HDPrivateKey(hdRoot);
+
+  return hdRootKey.derive(derivationPath).xprivkey;
+}
+
+function getPrivateHdRoot(mnemonic, mnemonicOptions) {
+  var hdPath = getHdPath(mnemonic, mnemonicOptions);
+
+  return new _bitcoreLib2.default.HDPrivateKey(hdPath);
+}
+
+function getPublicHdRoot(bip32XPublicKey) {
+  return new _bitcoreLib2.default.HDPublicKey(bip32XPublicKey);
+}
+
+function deriveKeyFromPassword(password, salt, scryptParams) {
+  return utils.deriveKeyFromPassword(password, scryptParams, DEFAULT_DERIVATION_KEY_LENGTH, salt);
+}
+
+function encryptData(dataToEncrypt, derivedKey, encryptionType, isPrivateKey) {
+  return encryption.encryptData({
+    derivedKey: derivedKey,
+    encryptionType: encryptionType,
+    data: dataToEncrypt,
+    isPrivateKey: !!isPrivateKey
+  });
+}
+
+function decryptData(dataToDecrypt, derivedKey, encryptionType, isPrivateKey) {
+  return encryption.decryptData({
+    derivedKey: derivedKey,
+    encryptionType: encryptionType,
+    data: dataToDecrypt,
+    isPrivateKey: !!isPrivateKey
+  });
+}
+
+function checkAddressValid(address) {
+  return utils.checkAddressValid(address);
+}
+
+function checkChecksumAddressValid(address) {
+  return utils.checkChecksumAddressValid(address);
+}
+
+function checkPrivateKeyValid(privateKey) {
+  return utils.checkPrivateKeyValid(privateKey);
+}
+
+function checkDerivationPathValid(derivationPath) {
+  return _bitcoreLib2.default.HDPrivateKey.isValidPath(derivationPath);
+}
+
+function checkWalletIsNotReadOnly(isReadOnly) {
+  if (isReadOnly) {
+    throw new Error('Wallet is read only');
+  }
+}
+
+function getAddressFromPrivateKey(privateKey) {
+  return utils.getAddressFromPrivateKey(privateKey);
+}
+
+function getXPubFromMnemonic(mnemonic, mnemonicOptionsUser) {
+  var mnemonicOptions = getMnemonicOptions(mnemonicOptionsUser);
+  var hdRoot = getPrivateHdRoot(mnemonic, mnemonicOptions);
+
+  return hdRoot.hdPublicKey.toString();
+}
+
+function encryptMnemonic(mnemonic, password, passwordOptionsUser) {
+  var mnemonicPad = utils.leftPadString(mnemonic, ' ', PADDED_MNEMONIC_LENGTH);
+  var passwordOptions = getPasswordOptions(passwordOptionsUser);
+
+  var salt = passwordOptions.salt,
+      scryptParams = passwordOptions.scryptParams,
+      encryptionType = passwordOptions.encryptionType;
+
+
+  var derivedKey = deriveKeyFromPassword(password, salt, scryptParams);
+
+  return encryptData(mnemonicPad, derivedKey, encryptionType, false);
+}
+
+function encryptPrivateKey(privateKey, password, passwordOptionsUser) {
+  var passwordOptions = getPasswordOptions(passwordOptionsUser);
+
+  var salt = passwordOptions.salt,
+      scryptParams = passwordOptions.scryptParams,
+      encryptionType = passwordOptions.encryptionType;
+
+
+  var derivedKey = deriveKeyFromPassword(password, salt, scryptParams);
+
+  return encryptData(privateKey, derivedKey, encryptionType, true);
+}
+
+function decryptMnemonic(mnemonic, password, passwordOptionsUser) {
+  var passwordOptions = getPasswordOptions(passwordOptionsUser);
+
+  var salt = passwordOptions.salt,
+      scryptParams = passwordOptions.scryptParams,
+      encryptionType = passwordOptions.encryptionType;
+
+
+  var derivedKey = deriveKeyFromPassword(password, salt, scryptParams);
+  var mnemonicPad = decryptData(mnemonic, derivedKey, encryptionType, true);
+
+  return mnemonicPad.trim();
+}
+
+function decryptPrivateKey(privateKey, password, passwordOptionsUser) {
+  var passwordOptions = getPasswordOptions(passwordOptionsUser);
+
+  var salt = passwordOptions.salt,
+      scryptParams = passwordOptions.scryptParams,
+      encryptionType = passwordOptions.encryptionType;
+
+
+  var derivedKey = deriveKeyFromPassword(password, salt, scryptParams);
+
+  return decryptData(privateKey, derivedKey, encryptionType, true);
+}
+
+function getPrivateKeyFromMnemonic(mnemonic, addressIndex, mnemonicOptions) {
+  var hdRoot = getPrivateHdRoot(mnemonic, mnemonicOptions);
+  var generatedKey = hdRoot.derive(addressIndex);
+
+  return generatedKey.privateKey.toString();
+}
+
+function generateAddress(hdRoot, index) {
+  var generatedKey = hdRoot.derive(index);
+  var publicKey = generatedKey.publicKey.toString();
+
+  return utils.getAddressFromPublicKey(publicKey);
+}
+
+function generateAddresses(bip32XPublicKey, start, end) {
+  var hdRoot = getPublicHdRoot(bip32XPublicKey);
+  var startIndex = start || 0;
+  var endIndex = end || startIndex;
+  var addressesCount = endIndex - startIndex;
+
+  // generate range from 0 to addressesCount
+  return Array.from(new Array(addressesCount + 1).keys()).map(function (currentIndex) {
+    return generateAddress(hdRoot, startIndex + currentIndex);
+  });
+}

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -5,6 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.checkBip32XPublicKeyValid = exports.checkMnemonicValid = exports.generateMnemonic = exports.testPassword = undefined;
 exports.generateSalt = generateSalt;
+exports.getChecksum = getChecksum;
 exports.leftPadString = leftPadString;
 exports.getPasswordOptions = getPasswordOptions;
 exports.getMnemonicOptions = getMnemonicOptions;
@@ -72,6 +73,10 @@ exports.checkMnemonicValid = _mnemonic.checkMnemonicValid;
 exports.checkBip32XPublicKeyValid = _mnemonic.checkBip32XPublicKeyValid;
 function generateSalt(byteCount) {
   return utils.generateSalt(byteCount);
+}
+
+function getChecksum(address) {
+  return utils.getChecksum(address);
 }
 
 function leftPadString(stringToPad, padChar, totalLength) {

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -88,12 +88,18 @@ function getPasswordOptions(options) {
 
   return !options ? {
     salt: salt,
+    passwordHint: '',
     scryptParams: DEFAULT_SCRYPT_PARAMS,
-    encryptionType: DEFAULT_ENCRYPTION_TYPE
+    encryptionType: DEFAULT_ENCRYPTION_TYPE,
+    saltBytesCount: DEFAULT_SALT_BYTES_COUNT,
+    derivedKeyLength: DEFAULT_DERIVATION_KEY_LENGTH
   } : {
     salt: options.salt || salt,
+    passwordHint: options.passwordHint || '',
     scryptParams: options.scryptParams || DEFAULT_SCRYPT_PARAMS,
-    encryptionType: options.encryptionType || DEFAULT_ENCRYPTION_TYPE
+    encryptionType: options.encryptionType || DEFAULT_ENCRYPTION_TYPE,
+    saltBytesCount: options.saltBytesCount || DEFAULT_SALT_BYTES_COUNT,
+    derivedKeyLength: options.derivedKeyLength || DEFAULT_DERIVATION_KEY_LENGTH
   };
 }
 

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -4,6 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.checkBip32XPublicKeyValid = exports.checkMnemonicValid = exports.generateMnemonic = exports.testPassword = undefined;
+exports.generateSalt = generateSalt;
 exports.getPasswordOptions = getPasswordOptions;
 exports.getMnemonicOptions = getMnemonicOptions;
 exports.getHdPath = getHdPath;
@@ -68,8 +69,12 @@ exports.testPassword = _password.testPassword;
 exports.generateMnemonic = _mnemonic.generateMnemonic;
 exports.checkMnemonicValid = _mnemonic.checkMnemonicValid;
 exports.checkBip32XPublicKeyValid = _mnemonic.checkBip32XPublicKeyValid;
+function generateSalt(byteCount) {
+  return utils.generateSalt(byteCount);
+}
+
 function getPasswordOptions(options) {
-  var salt = utils.generateSalt(DEFAULT_SALT_BYTES_COUNT);
+  var salt = generateSalt(DEFAULT_SALT_BYTES_COUNT);
 
   return !options ? {
     salt: salt,

--- a/lib/mnemonic.js
+++ b/lib/mnemonic.js
@@ -1,0 +1,68 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.generateMnemonic = generateMnemonic;
+exports.checkMnemonicValid = checkMnemonicValid;
+exports.checkBip32XPublicKeyValid = checkBip32XPublicKeyValid;
+
+var _bitcoreMnemonic = require('bitcore-mnemonic');
+
+var _bitcoreMnemonic2 = _interopRequireDefault(_bitcoreMnemonic);
+
+var _bitcoreLib = require('bitcore-lib');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var DEFAULT_RANDOM_BUFFER_LENGTH = 32;
+var BIP32_EXTENDABLE_PUBLIC_KEY_LENGTH = 111;
+var ENGLISH_WORDS = _bitcoreMnemonic2.default.Words.ENGLISH;
+
+function concatEntropyBuffers(entropyBuffer, randomBuffer) {
+  var totalEntropy = Buffer.concat([entropyBuffer, randomBuffer]);
+
+  if (totalEntropy.length !== entropyBuffer.length + randomBuffer.length) {
+    throw new Error('Concatenation of entropy buffers failed.');
+  }
+
+  return _bitcoreLib.crypto.Hash.sha256(totalEntropy);
+}
+
+function getHashedEntropy(entropy, randomBufferLength) {
+  if (!entropy) {
+    return null;
+  } else if (typeof entropy !== 'string') {
+    throw new TypeError('Entropy is set but not a string.');
+  }
+
+  var entropyBuffer = Buffer.from(entropy);
+  var randomBuffer = _bitcoreLib.crypto.Random.getRandomBuffer(randomBufferLength);
+
+  return concatEntropyBuffers(entropyBuffer, randomBuffer).slice(0, 16);
+}
+
+function generateMnemonic(entropy) {
+  var randomBufferLength = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : DEFAULT_RANDOM_BUFFER_LENGTH;
+
+  var hashedEntropy = getHashedEntropy(entropy, randomBufferLength);
+
+  var mnemonic = hashedEntropy ? new _bitcoreMnemonic2.default(hashedEntropy, ENGLISH_WORDS) : new _bitcoreMnemonic2.default(ENGLISH_WORDS);
+
+  return mnemonic.toString();
+}
+
+function checkMnemonicValid(mnemonic) {
+  return _bitcoreMnemonic2.default.isValid(mnemonic, ENGLISH_WORDS);
+}
+
+function checkBip32XPublicKeyValid(bip32XPublicKey) {
+  if (!bip32XPublicKey || bip32XPublicKey.length !== BIP32_EXTENDABLE_PUBLIC_KEY_LENGTH) {
+    return false;
+  }
+
+  var reLengthWithoutXPUB = BIP32_EXTENDABLE_PUBLIC_KEY_LENGTH - 4;
+  var re = new RegExp('^(xpub)([A-Z\\d]{' + reLengthWithoutXPUB + '})$', 'i');
+
+  return re.test(bip32XPublicKey);
+}

--- a/lib/password.js
+++ b/lib/password.js
@@ -1,0 +1,20 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.testPassword = testPassword;
+
+var _zxcvbn2 = require('zxcvbn');
+
+var _zxcvbn3 = _interopRequireDefault(_zxcvbn2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function testPassword(password) {
+  var _zxcvbn = (0, _zxcvbn3.default)(password),
+      score = _zxcvbn.score,
+      feedback = _zxcvbn.feedback;
+
+  return { score: score, feedback: feedback };
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,123 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.add0x = add0x;
+exports.checkChecksumAddressValid = checkChecksumAddressValid;
+exports.checkAddressValid = checkAddressValid;
+exports.checkPrivateKeyValid = checkPrivateKeyValid;
+exports.getAddressFromPublicKey = getAddressFromPublicKey;
+exports.getAddressFromPrivateKey = getAddressFromPrivateKey;
+exports.deriveKeyFromPassword = deriveKeyFromPassword;
+exports.leftPadString = leftPadString;
+exports.generateSalt = generateSalt;
+
+var _scrypt = require('scrypt.js');
+
+var _scrypt2 = _interopRequireDefault(_scrypt);
+
+var _cryptoJs = require('crypto-js');
+
+var _cryptoJs2 = _interopRequireDefault(_cryptoJs);
+
+var _bitcoreLib = require('bitcore-lib');
+
+var _elliptic = require('elliptic');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/* eslint-enable no-use-before-define */
+
+/* eslint-disable no-use-before-define */
+var RE_HEX_PREFIX = /^0x/i;
+var ENCODER = _cryptoJs2.default.enc.Hex;
+
+var ec = new _elliptic.ec('secp256k1');
+
+function strip0x(data) {
+  return data.replace(RE_HEX_PREFIX, '');
+}
+
+function add0x(data) {
+  if (RE_HEX_PREFIX.test(data)) {
+    return data;
+  }
+
+  return '0x' + data;
+}
+
+function getChecksum(address) {
+  var addressLowerCase = strip0x(address).toLowerCase();
+  var hash = _cryptoJs2.default.SHA3(addressLowerCase, { outputLength: 256 }).toString(ENCODER);
+
+  var checksum = addressLowerCase.split('').map(function (symbol, index) {
+    return parseInt(hash[index], 16) >= 8 ? symbol.toUpperCase() : symbol;
+  }).join('');
+
+  return add0x(checksum);
+}
+
+function checkNormalizedAddress(address) {
+  var isAddressLowerCase = /^0x[0-9a-f]{40}$/.test(address);
+  var isAddressUpperCase = /^0x[0-9A-F]{40}$/.test(address);
+
+  return isAddressLowerCase || isAddressUpperCase;
+}
+
+function checkChecksumAddressValid(address) {
+  return (/^0x[0-9a-fA-F]{40}$/i.test(address) && getChecksum(address) === address
+  );
+}
+
+function checkAddressValid(address) {
+  return checkNormalizedAddress(address) || checkChecksumAddressValid(address);
+}
+
+function checkPrivateKeyValid(privateKey) {
+  return (/^0x[0-9a-fA-F]{64}$/i.test(privateKey)
+  );
+}
+
+function getAddressFromKeyPair(keyPair) {
+  var isCompact = false;
+  var publicKey = keyPair.getPublic(isCompact, 'hex').slice(2);
+  var publicKeyWordArray = ENCODER.parse(publicKey);
+  var hash = _cryptoJs2.default.SHA3(publicKeyWordArray, { outputLength: 256 });
+  var address = hash.toString(ENCODER).slice(24);
+
+  return getChecksum(address);
+}
+
+function getAddressFromPublicKey(publicKey) {
+  var keyPair = ec.keyFromPublic(publicKey, 'hex');
+
+  return getAddressFromKeyPair(keyPair);
+}
+
+function getAddressFromPrivateKey(privateKey) {
+  var keyPair = ec.genKeyPair();
+  keyPair._importPrivate(strip0x(privateKey), 'hex');
+
+  return getAddressFromKeyPair(keyPair);
+}
+
+function deriveKeyFromPassword(password, scryptParams, derivedKeyLength, salt) {
+  var N = scryptParams.N,
+      r = scryptParams.r,
+      p = scryptParams.p;
+
+  var derivedKey = (0, _scrypt2.default)(password, salt, N, r, p, derivedKeyLength);
+
+  return new Uint8Array(derivedKey);
+}
+
+function leftPadString(stringToPad, padChar, totalLength) {
+  var leftPad = padChar.repeat(totalLength - stringToPad.length);
+
+  return '' + leftPad + stringToPad;
+}
+
+function generateSalt(byteCount) {
+  return _bitcoreLib.crypto.Random.getRandomBuffer(byteCount).toString('base64');
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.add0x = add0x;
+exports.getChecksum = getChecksum;
 exports.checkChecksumAddressValid = checkChecksumAddressValid;
 exports.checkAddressValid = checkAddressValid;
 exports.checkPrivateKeyValid = checkPrivateKeyValid;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1222,9 +1222,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
     },
     "bitcore-lib": {
@@ -1417,8 +1417,8 @@
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000885",
-        "electron-to-chromium": "1.3.67"
+        "caniuse-lite": "1.0.30000886",
+        "electron-to-chromium": "1.3.70"
       }
     },
     "buffer": {
@@ -1503,9 +1503,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000885",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
-      "integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==",
+      "version": "1.0.30000886",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000886.tgz",
+      "integrity": "sha512-xpYuY7rqc5+4q1n/l1BfSgIndaNqvXWKZ0Vk0ZXzVncCAkn0+huvIIPwcSL5YRJoW4MSRsgyNbjnKuh45GmknA==",
       "dev": true
     },
     "center-align": {
@@ -1556,9 +1556,9 @@
       }
     },
     "ci-info": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.5.1.tgz",
-      "integrity": "sha512-fKFIKXaYiL1exImwJ0AhR/6jxFPSKQBk2ayV5NiNoruUs2+rxC2kNw0EG+1Z9dugZRdCrppskQ8DN2cyaUM1Hw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
     },
     "cipher-base": {
@@ -2099,9 +2099,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.67.tgz",
-      "integrity": "sha512-h3zEBLdHvsKfaXv1SHAtykJyNtwYFEKkrWGSFyW1BzGgPQ4ykAzD5Hd8C5MZGTAEhkCKmtyIwYUrapsI0xfKww==",
+      "version": "1.3.70",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.70.tgz",
+      "integrity": "sha512-WYMjqCnPVS5JA+XvwEnpwucJpVi2+q9cdCFpbhxgWGsCtforFBEkuP9+nCyy/wnU/0SyLcLRIeZct9ayMGcXoQ==",
       "dev": true
     },
     "elegant-spinner": {
@@ -2187,7 +2187,7 @@
       "requires": {
         "is-callable": "1.1.4",
         "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-symbol": "1.0.2"
       }
     },
     "es5-ext": {
@@ -3590,6 +3590,12 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -3898,7 +3904,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "1.12.0"
       }
     },
     "is-buffer": {
@@ -3909,7 +3915,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3928,7 +3934,7 @@
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.5.1"
+        "ci-info": "1.6.0"
       }
     },
     "is-data-descriptor": {
@@ -4138,10 +4144,13 @@
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "1.0.0"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -4568,7 +4577,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -4579,9 +4588,9 @@
       }
     },
     "loader-runner": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-      "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
+      "integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==",
       "dev": true
     },
     "loader-utils": {
@@ -7104,7 +7113,7 @@
       "requires": {
         "source-map": "0.5.7",
         "uglify-js": "2.8.29",
-        "webpack-sources": "1.2.0"
+        "webpack-sources": "1.3.0"
       }
     },
     "union-value": {
@@ -7249,11 +7258,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "v8flags": {
       "version": "2.1.1",
@@ -7653,7 +7657,7 @@
         "interpret": "1.1.0",
         "json-loader": "0.5.7",
         "json5": "0.5.1",
-        "loader-runner": "2.3.0",
+        "loader-runner": "2.3.1",
         "loader-utils": "1.1.0",
         "memory-fs": "0.4.1",
         "mkdirp": "0.5.1",
@@ -7663,7 +7667,7 @@
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
         "watchpack": "1.6.0",
-        "webpack-sources": "1.2.0",
+        "webpack-sources": "1.3.0",
         "yargs": "8.0.2"
       },
       "dependencies": {
@@ -7685,9 +7689,9 @@
       }
     },
     "webpack-sources": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.2.0.tgz",
-      "integrity": "sha512-9BZwxR85dNsjWz3blyxdOhTgtnQvv3OEs5xofI0wPYTwu5kaWxS08UuD1oI7WLBLpRO+ylf0ofnXLXWmGb2WMw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
+      "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
       "dev": true,
       "requires": {
         "source-list-map": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "scrypt.js": "0.2.0",
     "tweetnacl": "1.0.0",
     "tweetnacl-util": "0.15.0",
-    "uuid": "3.1.0",
     "zxcvbn": "4.4.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run clean && ./node_modules/.bin/babel ./src --out-dir ./lib",
     "build": "npm run compile && npm test",
     "precommit": "npm run flow && ./node_modules/.bin/lint-staged",
-    "prepush": "npm run build",
+    "prepush": "npm run compile",
     "postcheckout": "npm i"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // @flow
 
-import keystore from './keystore'
+import * as keystore from './keystore'
 
 export default keystore

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -66,12 +66,18 @@ export function getPasswordOptions(options: ?PasswordOptionsUser): PasswordOptio
 
   return !options ? {
     salt,
+    passwordHint: '',
     scryptParams: DEFAULT_SCRYPT_PARAMS,
     encryptionType: DEFAULT_ENCRYPTION_TYPE,
+    saltBytesCount: DEFAULT_SALT_BYTES_COUNT,
+    derivedKeyLength: DEFAULT_DERIVATION_KEY_LENGTH,
   } : {
     salt: options.salt || salt,
+    passwordHint: options.passwordHint || '',
     scryptParams: options.scryptParams || DEFAULT_SCRYPT_PARAMS,
     encryptionType: options.encryptionType || DEFAULT_ENCRYPTION_TYPE,
+    saltBytesCount: options.saltBytesCount || DEFAULT_SALT_BYTES_COUNT,
+    derivedKeyLength: options.derivedKeyLength || DEFAULT_DERIVATION_KEY_LENGTH,
   }
 }
 

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -60,17 +60,15 @@ export function leftPadString(stringToPad: string, padChar: string, totalLength:
 export function getPasswordOptions(options: ?PasswordOptionsUser): PasswordOptions {
   const salt: string = generateSalt(DEFAULT_SALT_BYTES_COUNT)
 
-  return !options
-    ? {
-      salt,
-      scryptParams: DEFAULT_SCRYPT_PARAMS,
-      encryptionType: DEFAULT_ENCRYPTION_TYPE,
-    }
-    : {
-      salt,
-      scryptParams: options.scryptParams || DEFAULT_SCRYPT_PARAMS,
-      encryptionType: options.encryptionType || DEFAULT_ENCRYPTION_TYPE,
-    }
+  return !options ? {
+    salt,
+    scryptParams: DEFAULT_SCRYPT_PARAMS,
+    encryptionType: DEFAULT_ENCRYPTION_TYPE,
+  } : {
+    salt: options.salt || salt,
+    scryptParams: options.scryptParams || DEFAULT_SCRYPT_PARAMS,
+    encryptionType: options.encryptionType || DEFAULT_ENCRYPTION_TYPE,
+  }
 }
 
 export function getMnemonicOptions(options: ?MnemonicOptionsUser): MnemonicOptions {

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -53,6 +53,10 @@ export function generateSalt(byteCount: number): string {
   return utils.generateSalt(byteCount)
 }
 
+export function getChecksum(address: string): string {
+  return utils.getChecksum(address)
+}
+
 export function leftPadString(stringToPad: string, padChar: string, totalLength: number) {
   return utils.leftPadString(stringToPad, padChar, totalLength)
 }

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -57,6 +57,10 @@ export function getChecksum(address: string): string {
   return utils.getChecksum(address)
 }
 
+export function add0x(data: string): string {
+  return utils.add0x(data)
+}
+
 export function leftPadString(stringToPad: string, padChar: string, totalLength: number) {
   return utils.leftPadString(stringToPad, padChar, totalLength)
 }

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -1,6 +1,5 @@
 // @flow
 
-import uuidv4 from 'uuid/v4'
 import bitcore from 'bitcore-lib'
 import Mnemonic from 'bitcore-mnemonic'
 
@@ -8,8 +7,6 @@ import { testPassword } from './password'
 import { generateMnemonic, checkMnemonicValid, checkBip32XPublicKeyValid } from './mnemonic'
 import * as utils from './utils'
 import * as encryption from './encryption'
-
-import packageData from '../package.json'
 
 type HDPublicKey = {|
   +toString: () => string,
@@ -32,20 +29,6 @@ type HDPrivateKey = {|
   |},
 |}
 
-type PasswordOptionsUser = {|
-  scryptParams?: ScryptParams,
-  encryptionType?: string,
-  saltBytesCount?: number,
-  derivedKeyLength?: number,
-|}
-
-type MnemonicOptionsUser = {|
-  network?: ?Network,
-  passphrase?: ?string,
-  derivationPath?: string,
-  paddedMnemonicLength?: number,
-|}
-
 const DEFAULT_SCRYPT_PARAMS: ScryptParams = {
   N: 2 ** 18,
   r: 8,
@@ -55,78 +38,28 @@ const DEFAULT_SCRYPT_PARAMS: ScryptParams = {
 const DEFAULT_NETWORK: string = 'livenet'
 const ADDRESS_TYPE: 'address' = 'address'
 const MNEMONIC_TYPE: 'mnemonic' = 'mnemonic'
-const CURRENT_VERSION: string = packageData.version
 const DEFAULT_ENCRYPTION_TYPE: string = 'nacl.secretbox'
 const DEFAULT_DERIVATION_PATH: string = 'm/44\'/60\'/0\'/0'
 const PADDED_MNEMONIC_LENGTH: number = 120
+const TEST_PASSWORD_DATA_LENGTH: number = 120
 const DEFAULT_SALT_BYTES_COUNT: number = 32
 const DEFAULT_DERIVATION_KEY_LENGTH: number = 32
 
-function checkAddressValid(address: string): boolean {
-  return utils.checkAddressValid(address)
-}
-
-function checkChecksumAddressValid(address: string): boolean {
-  return utils.checkChecksumAddressValid(address)
-}
-
-function checkPrivateKeyValid(privateKey: string): boolean {
-  return utils.checkPrivateKeyValid(privateKey)
-}
-
-function checkDerivationPathValid(derivationPath: string): boolean {
-  return bitcore.HDPrivateKey.isValidPath(derivationPath)
-}
-
-function _checkNotReadOnly(isReadOnly: boolean): void {
-  if (isReadOnly) {
-    throw new Error('Wallet is read only')
-  }
-}
-
-function _checkMnemonicType(type: WalletType): void {
-  if (type !== MNEMONIC_TYPE) {
-    throw new Error('Wallet type is not mnemonic')
-  }
-}
-
-function _checkWalletUniqueness(
-  wallets: Wallets,
-  uniqueProperty: string,
-  propertyName: string,
-): void {
-  const foundWallet: ?Wallet = wallets.find((wallet: Wallet): boolean => {
-    const propertyValue: string = wallet[propertyName]
-
-    return propertyValue ? (propertyValue.toLowerCase() === uniqueProperty.toLowerCase()) : false
-  })
-
-  if (foundWallet) {
-    throw new Error(`Wallet with this ${propertyName} already exists`)
-  }
-}
-
 function _getPasswordOptions(options: ?PasswordOptionsUser): PasswordOptions {
-  const saltBytesCount: number = options
-    ? options.saltBytesCount || DEFAULT_SALT_BYTES_COUNT
-    : DEFAULT_SALT_BYTES_COUNT
-
-  const salt: string = utils.generateSalt(saltBytesCount)
+  const salt: string = utils.generateSalt(DEFAULT_SALT_BYTES_COUNT)
 
   return !options
     ? {
       salt,
-      saltBytesCount,
+      passwordHint: null,
       scryptParams: DEFAULT_SCRYPT_PARAMS,
       encryptionType: DEFAULT_ENCRYPTION_TYPE,
-      derivedKeyLength: DEFAULT_DERIVATION_KEY_LENGTH,
     }
     : {
       salt,
-      saltBytesCount,
+      passwordHint: options.passwordHint,
       scryptParams: options.scryptParams || DEFAULT_SCRYPT_PARAMS,
       encryptionType: options.encryptionType || DEFAULT_ENCRYPTION_TYPE,
-      derivedKeyLength: options.derivedKeyLength || DEFAULT_DERIVATION_KEY_LENGTH,
     }
 }
 
@@ -167,287 +100,40 @@ function _getPublicHdRoot(bip32XPublicKey: string): HDPublicKey {
   return new bitcore.HDPublicKey(bip32XPublicKey)
 }
 
-function _getXPubFromMnemonic(mnemonic: string, mnemonicOptions: MnemonicOptions): string {
-  const hdRoot: HDPrivateKey = _getPrivateHdRoot(mnemonic, mnemonicOptions)
-
-  return hdRoot.hdPublicKey.toString()
-}
-
 function _deriveKeyFromPassword(
   password: string,
-  salt: ?string,
-  scryptParams: ?ScryptParams = DEFAULT_SCRYPT_PARAMS,
-  derivedKeyLength: ?number = DEFAULT_DERIVATION_KEY_LENGTH,
+  salt: string,
+  scryptParams: ScryptParams,
 ): Uint8Array {
-  if (!password) {
-    throw new Error('Password is empty')
-  }
-
-  if (!(salt && scryptParams && derivedKeyLength)) {
-    throw new Error('Invalid wallet properties')
-  }
-
-  return utils.deriveKeyFromPassword(password, scryptParams, derivedKeyLength, salt)
+  return utils.deriveKeyFromPassword(password, scryptParams, DEFAULT_DERIVATION_KEY_LENGTH, salt)
 }
 
 function _encryptData(
   dataToEncrypt: string,
   derivedKey: Uint8Array,
-  encryptionType?: ?string,
+  encryptionType: string,
   isPrivateKey?: boolean,
 ): EncryptedData {
   return encryption.encryptData({
     derivedKey,
+    encryptionType,
     data: dataToEncrypt,
     isPrivateKey: !!isPrivateKey,
-    encryptionType: encryptionType || DEFAULT_ENCRYPTION_TYPE,
-  })
-}
-
-function _encryptPrivateKey(
-  dataToEncrypt: string,
-  derivedKey: Uint8Array,
-  encryptionType?: string,
-): EncryptedData {
-  return _encryptData(dataToEncrypt, derivedKey, encryptionType, true)
-}
-
-function _appendWallet(wallets: Wallets, wallet: Wallet): Wallets {
-  return wallets.concat(wallet)
-}
-
-function _createMnemonicWallet(
-  wallets: Wallets,
-  walletData: WalletData,
-  password: ?string,
-): Wallets {
-  const {
-    id,
-    data,
-    name,
-    passwordOptions,
-    mnemonicOptions,
-  } = walletData
-
-  if (!password) {
-    throw new Error('Password required')
-  }
-
-  const mnemonic: string = data.toLowerCase()
-
-  const {
-    derivationPath,
-    paddedMnemonicLength,
-  } = mnemonicOptions
-
-  if (!checkDerivationPathValid(derivationPath)) {
-    throw new Error('Invalid derivation path')
-  }
-
-  const xpub: string = _getXPubFromMnemonic(mnemonic, mnemonicOptions)
-
-  _checkWalletUniqueness(wallets, xpub, 'bip32XPublicKey')
-
-  const {
-    salt,
-    scryptParams,
-    encryptionType,
-    derivedKeyLength,
-  } = passwordOptions
-
-  const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams, derivedKeyLength)
-  const mnemonicPad: string = utils.leftPadString(mnemonic, ' ', paddedMnemonicLength)
-  const mnemonicEnc: EncryptedData = _encryptData(mnemonicPad, dKey, encryptionType)
-
-  return _appendWallet(wallets, {
-    id,
-    name,
-    passwordOptions,
-    mnemonicOptions,
-    addressIndex: 0,
-    isReadOnly: false,
-    type: MNEMONIC_TYPE,
-    bip32XPublicKey: xpub,
-    customType: 'mnemonic',
-    encrypted: {
-      privateKey: null,
-      mnemonic: mnemonicEnc,
-    },
-    /**
-     * Another wallet data, necessary for consistency of types
-     */
-    address: null,
-  })
-}
-
-function _createReadOnlyMnemonicWallet(wallets: Wallets, walletData: WalletData): Wallets {
-  const {
-    id,
-    data,
-    name,
-  } = walletData
-
-  _checkWalletUniqueness(wallets, data, 'bip32XPublicKey')
-
-  return _appendWallet(wallets, {
-    id,
-    name,
-    addressIndex: 0,
-    isReadOnly: true,
-    type: MNEMONIC_TYPE,
-    bip32XPublicKey: data,
-    customType: 'bip32Xpub',
-    encrypted: {
-      mnemonic: null,
-      privateKey: null,
-    },
-    /**
-     * Another wallet data, necessary for consistency of types
-     */
-    address: null,
-    passwordOptions: null,
-    mnemonicOptions: null,
-  })
-}
-
-function _createAddressWallet(
-  wallets: Wallets,
-  walletData: WalletData,
-  password: ?string,
-): Wallets {
-  const {
-    id,
-    data,
-    name,
-    passwordOptions,
-  } = walletData
-
-  if (!password) {
-    throw new Error('Password required')
-  }
-
-  const address: string = utils.getAddressFromPrivateKey(data)
-
-  _checkWalletUniqueness(wallets, address, 'address')
-
-  const {
-    salt,
-    scryptParams,
-    encryptionType,
-    derivedKeyLength,
-  } = passwordOptions
-
-  const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams, derivedKeyLength)
-
-  return _appendWallet(wallets, {
-    id,
-    name,
-    address,
-    passwordOptions,
-    isReadOnly: false,
-    type: ADDRESS_TYPE,
-    customType: 'privateKey',
-    encrypted: {
-      mnemonic: null,
-      privateKey: _encryptPrivateKey(data, dKey, encryptionType),
-    },
-    /**
-     * Another wallet data, necessary for consistency of types
-     */
-    addressIndex: null,
-    mnemonicOptions: null,
-    bip32XPublicKey: null,
-  })
-}
-
-function _createReadOnlyAddressWallet(wallets: Wallets, walletData: WalletData): Wallets {
-  const {
-    id,
-    data,
-    name,
-  } = walletData
-
-  _checkWalletUniqueness(wallets, data, 'address')
-
-  return _appendWallet(wallets, {
-    id,
-    name,
-    address: data,
-    isReadOnly: true,
-    type: ADDRESS_TYPE,
-    customType: 'address',
-    encrypted: {
-      mnemonic: null,
-      privateKey: null,
-    },
-    /**
-     * Another wallet data, necessary for consistency of types
-     */
-    addressIndex: null,
-    bip32XPublicKey: null,
-    passwordOptions: null,
-    mnemonicOptions: null,
   })
 }
 
 function _decryptData(
   dataToDecrypt: EncryptedData,
   derivedKey: Uint8Array,
-  encryptionType?: ?string,
+  encryptionType: string,
   isPrivateKey?: boolean,
 ): string {
   return encryption.decryptData({
     derivedKey,
+    encryptionType,
     data: dataToDecrypt,
     isPrivateKey: !!isPrivateKey,
-    encryptionType: encryptionType || DEFAULT_ENCRYPTION_TYPE,
   })
-}
-
-function _decryptPrivateKey(
-  dataToDecrypt: EncryptedData,
-  derivedKey: Uint8Array,
-  encryptionType?: ?string,
-): string {
-  return _decryptData(dataToDecrypt, derivedKey, encryptionType, true)
-}
-
-function _getPrivateKeyFromMnemonic(wallet: Wallet, dKey: Uint8Array): string {
-  const {
-    encrypted,
-    addressIndex,
-    passwordOptions,
-    mnemonicOptions,
-  }: Wallet = wallet
-
-  if (!(encrypted.mnemonic && passwordOptions && mnemonicOptions)) {
-    throw new Error('Invalid wallet')
-  }
-
-  const mnemonic: string = _decryptData(encrypted.mnemonic, dKey, passwordOptions.encryptionType)
-  const hdRoot: HDPrivateKey = _getPrivateHdRoot(mnemonic.trim(), mnemonicOptions)
-  const generatedKey: HDPrivateKey = hdRoot.derive(addressIndex || 0)
-
-  return generatedKey.privateKey.toString()
-}
-
-function _generateAddress(hdRoot: HDPublicKey, index: number): string {
-  const generatedKey: HDPublicKey = hdRoot.derive(index)
-  const publicKey: string = generatedKey.publicKey.toString()
-
-  return utils.getAddressFromPublicKey(publicKey)
-}
-
-function _generateAddresses(bip32XPublicKey: string, start: ?number, end: ?number): Array<string> {
-  const hdRoot: HDPublicKey = _getPublicHdRoot(bip32XPublicKey)
-  const startIndex: number = start || 0
-  const endIndex: number = end || startIndex
-  const addressesCount: number = endIndex - startIndex
-
-  // generate range from 0 to addressesCount
-  return Array
-    .from(new Array(addressesCount + 1).keys())
-    .map((currentIndex: number): string => _generateAddress(hdRoot, startIndex + currentIndex))
 }
 
 function _testPassword(password: string): void {
@@ -458,206 +144,228 @@ function _testPassword(password: string): void {
   }
 }
 
-function getWallet(wallets: Wallets, walletId: string): Wallet {
-  if (!walletId) {
-    throw new Error('Wallet ID not provided')
-  }
-
-  const wallet: ?Wallet = wallets.find(({ id }: Wallet): boolean => (walletId === id))
-
-  if (!wallet) {
-    throw new Error(`Wallet with id ${walletId} not found`)
-  }
-
-  return { ...wallet }
-}
-
-function createWallet(wallets: Wallets, walletNewData: WalletNewData, password?: string): Wallets {
-  const {
-    scryptParams,
-    data,
-    name,
-    network,
-    passphrase,
-    derivationPath,
-    encryptionType,
-    saltBytesCount,
-    derivedKeyLength,
-    paddedMnemonicLength,
-  } = walletNewData
-
-  if (password) {
-    _testPassword(password)
-  }
-
-  if (name) {
-    _checkWalletUniqueness(wallets, name, 'name')
-  }
-
-  const id: string = uuidv4()
-
-  const passwordOptions: PasswordOptions = _getPasswordOptions({
-    scryptParams,
-    saltBytesCount,
-    encryptionType,
-    derivedKeyLength,
-  })
-
-  const mnemonicOptions: MnemonicOptions = _getMnemonicOptions({
-    network,
-    passphrase,
-    derivationPath,
-    paddedMnemonicLength,
-  })
-
-  const walletData: WalletData = {
-    id,
-    data,
-    passwordOptions,
-    mnemonicOptions,
-    name: name || id,
-  }
-
-  if (checkMnemonicValid(data)) {
-    return _createMnemonicWallet(wallets, walletData, password)
-  } else if (checkBip32XPublicKeyValid(data)) {
-    return _createReadOnlyMnemonicWallet(wallets, walletData)
-  } else if (checkPrivateKeyValid(data)) {
-    return _createAddressWallet(wallets, walletData, password)
-  } else if (checkAddressValid(data)) {
-    return _createReadOnlyAddressWallet(wallets, walletData)
-  } else {
-    throw new Error('Wallet data not provided or invalid')
-  }
-}
-
-function removeWallet(wallets: Wallets, walletId: string): Wallets {
-  const wallet: Wallet = getWallet(wallets, walletId)
-
-  return wallets.filter(({ id }: Wallet): boolean => (wallet.id !== id))
-}
-
-function updateWallet(
-  wallets: Wallets,
-  walletId: string,
-  updatedData: WalletUpdatedData,
-): Wallets {
-  const {
-    encrypted,
-    passwordOptions,
-    mnemonicOptions,
-    name,
-    customType,
-    bip32XPublicKey,
-    addressIndex,
-    isReadOnly,
-  } = updatedData
-
-  const wallet: Wallet = getWallet(wallets, walletId)
-
-  const newWallet: Wallet = {
-    ...wallet,
-    encrypted: encrypted || wallet.encrypted,
-    passwordOptions: passwordOptions || wallet.passwordOptions,
-    mnemonicOptions: mnemonicOptions || wallet.mnemonicOptions,
-    name: name || wallet.name,
-    customType: customType || wallet.customType,
-    bip32XPublicKey: bip32XPublicKey || wallet.bip32XPublicKey,
-    addressIndex: addressIndex || wallet.addressIndex,
-    isReadOnly: (typeof (isReadOnly) === 'boolean') ? isReadOnly : wallet.isReadOnly,
-  }
-
-  const newWallets: Wallets = removeWallet(wallets, walletId)
-
-  return _appendWallet(newWallets, newWallet)
-}
-
-function addMnemonic(
-  wallets: Wallets,
-  walletId: string,
-  mnemonicUser: string,
-  password: string,
-  passwordOptionsUser?: ?PasswordOptionsUser,
-  mnemonicOptionsUser?: ?MnemonicOptionsUser,
-): Wallets {
-  _testPassword(password)
-
+function _reEncryptWallet(
+  wallet: Wallet,
+  derivedKey: Uint8Array,
+  newDerivedKey: Uint8Array,
+  encryptionType: string,
+  newEncryptionType: string,
+): Wallet {
   const {
     type,
-    bip32XPublicKey,
+    encrypted,
     isReadOnly,
-  }: Wallet = getWallet(wallets, walletId)
+  }: Wallet = wallet
 
-  if ((type !== MNEMONIC_TYPE) || !isReadOnly || !bip32XPublicKey) {
-    throw new Error('Invalid wallet type')
+  if (isReadOnly) {
+    return wallet
   }
 
-  const mnemonic: string = mnemonicUser.toLowerCase()
+  if ((type === MNEMONIC_TYPE) && encrypted.mnemonic) {
+    const mnemonicDec: string = _decryptData(encrypted.mnemonic, derivedKey, encryptionType)
+
+    return {
+      ...wallet,
+      encrypted: {
+        ...encrypted,
+        mnemonic: _encryptData(mnemonicDec, newDerivedKey, newEncryptionType),
+      },
+    }
+  } else if ((type === ADDRESS_TYPE) && encrypted.privateKey) {
+    const privateKeyDec: string = _decryptData(encrypted.privateKey, derivedKey, encryptionType)
+
+    return {
+      ...wallet,
+      encrypted: {
+        ...encrypted,
+        privateKey: _encryptData(privateKeyDec, newDerivedKey, newEncryptionType),
+      },
+    }
+  }
+
+  return wallet
+}
+
+function _reEncryptWallets(
+  wallets: Wallets,
+  derivedKey: Uint8Array,
+  newDerivedKey: Uint8Array,
+  encryptionType: string,
+  newEncryptionType: string,
+): Wallets {
+  return wallets.map((wallet: Wallet): Wallet => _reEncryptWallet(
+    wallet,
+    derivedKey,
+    newDerivedKey,
+    encryptionType,
+    newEncryptionType,
+  ))
+}
+
+function checkAddressValid(address: string): boolean {
+  return utils.checkAddressValid(address)
+}
+
+function checkChecksumAddressValid(address: string): boolean {
+  return utils.checkChecksumAddressValid(address)
+}
+
+function checkPrivateKeyValid(privateKey: string): boolean {
+  return utils.checkPrivateKeyValid(privateKey)
+}
+
+function checkDerivationPathValid(derivationPath: string): boolean {
+  return bitcore.HDPrivateKey.isValidPath(derivationPath)
+}
+
+function checkWalletIsNotReadOnly(isReadOnly: boolean): void {
+  if (isReadOnly) {
+    throw new Error('Wallet is read only')
+  }
+}
+
+function checkWalletIsMnemonicType(type: WalletType): void {
+  if (type !== MNEMONIC_TYPE) {
+    throw new Error('Wallet type is not mnemonic')
+  }
+}
+
+function checkWalletUniqueness(
+  wallets: Wallets,
+  uniqueProperty: string,
+  propertyName: string,
+): void {
+  const foundWallet: ?Wallet = wallets.find((wallet: Wallet): boolean => {
+    const propertyValue: string = wallet[propertyName]
+
+    return propertyValue ? (propertyValue.toLowerCase() === uniqueProperty.toLowerCase()) : false
+  })
+
+  if (foundWallet) {
+    throw new Error(`Wallet with this ${propertyName} already exists`)
+  }
+}
+
+function getAddressFromPrivateKey(privateKey: string): string {
+  return utils.getAddressFromPrivateKey(privateKey)
+}
+
+function getXPubFromMnemonic(mnemonic: string, mnemonicOptionsUser: MnemonicOptionsUser): string {
   const mnemonicOptions: MnemonicOptions = _getMnemonicOptions(mnemonicOptionsUser)
+  const hdRoot: HDPrivateKey = _getPrivateHdRoot(mnemonic, mnemonicOptions)
 
-  const {
-    derivationPath,
-    paddedMnemonicLength,
-  }: MnemonicOptions = mnemonicOptions
+  return hdRoot.hdPublicKey.toString()
+}
 
-  if (!checkDerivationPathValid(derivationPath)) {
-    throw new Error('Invalid derivation path')
-  }
-
-  const xpubFromMnemonic: string = _getXPubFromMnemonic(mnemonic, mnemonicOptions)
-
-  if (bip32XPublicKey.toLowerCase() !== xpubFromMnemonic.toLowerCase()) {
-    throw new Error('This private key is not pair with existed address')
-  }
-
+function encryptMnemonic(
+  mnemonic: string,
+  password: string,
+  passwordOptionsUser?: ?PasswordOptionsUser,
+): EncryptedData {
+  const mnemonicPad: string = utils.leftPadString(mnemonic, ' ', PADDED_MNEMONIC_LENGTH)
   const passwordOptions: PasswordOptions = _getPasswordOptions(passwordOptionsUser)
 
   const {
     salt,
     scryptParams,
     encryptionType,
-    derivedKeyLength,
-  }: PasswordOptions = passwordOptions
+  } = passwordOptions
 
-  const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams, derivedKeyLength)
-  const mnemonicPad: string = utils.leftPadString(mnemonic, ' ', paddedMnemonicLength)
+  const derivedKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams)
 
-  return updateWallet(wallets, walletId, {
-    passwordOptions,
-    mnemonicOptions,
-    encrypted: {
-      mnemonic: _encryptData(mnemonicPad, dKey, encryptionType),
-      privateKey: null,
-    },
-    customType: 'mnemonic',
-    isReadOnly: false,
-  })
+  return _encryptData(mnemonicPad, derivedKey, encryptionType, false)
 }
 
-function addPrivateKey(
-  wallets: Wallets,
-  walletId: string,
+function encryptPrivateKey(
   privateKey: string,
   password: string,
   passwordOptionsUser?: ?PasswordOptionsUser,
-): Wallets {
-  _testPassword(password)
+): EncryptedData {
+  const passwordOptions: PasswordOptions = _getPasswordOptions(passwordOptionsUser)
 
   const {
-    type,
-    address,
-    isReadOnly,
-  }: Wallet = getWallet(wallets, walletId)
+    salt,
+    scryptParams,
+    encryptionType,
+  } = passwordOptions
 
-  if ((type !== ADDRESS_TYPE) || !isReadOnly || !address) {
-    throw new Error('Invalid wallet type')
-  }
+  const derivedKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams)
 
-  const addressFromPrivateKey: string = utils.getAddressFromPrivateKey(privateKey)
+  return _encryptData(privateKey, derivedKey, encryptionType, true)
+}
 
-  if (address.toLowerCase() !== addressFromPrivateKey.toLowerCase()) {
-    throw new Error('This private key is not pair with existed address')
-  }
+function decryptMnemonic(
+  mnemonic: EncryptedData,
+  password: string,
+  passwordOptionsUser?: ?PasswordOptionsUser,
+): string {
+  const passwordOptions: PasswordOptions = _getPasswordOptions(passwordOptionsUser)
+
+  const {
+    salt,
+    scryptParams,
+    encryptionType,
+  } = passwordOptions
+
+  const derivedKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams)
+  const mnemonicPad: string = _decryptData(mnemonic, derivedKey, encryptionType, true)
+
+  return mnemonicPad.trim()
+}
+
+function decryptPrivateKey(
+  privateKey: EncryptedData,
+  password: string,
+  passwordOptionsUser?: ?PasswordOptionsUser,
+): string {
+  const passwordOptions: PasswordOptions = _getPasswordOptions(passwordOptionsUser)
+
+  const {
+    salt,
+    scryptParams,
+    encryptionType,
+  } = passwordOptions
+
+  const derivedKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams)
+
+  return _decryptData(privateKey, derivedKey, encryptionType, true)
+}
+
+function getPrivateKeyFromMnemonic(
+  mnemonic: string,
+  addressIndex: number,
+  mnemonicOptions: MnemonicOptions,
+): string {
+  const hdRoot: HDPrivateKey = _getPrivateHdRoot(mnemonic, mnemonicOptions)
+  const generatedKey: HDPrivateKey = hdRoot.derive(addressIndex)
+
+  return generatedKey.privateKey.toString()
+}
+
+function generateAddress(hdRoot: HDPublicKey, index: number): string {
+  const generatedKey: HDPublicKey = hdRoot.derive(index)
+  const publicKey: string = generatedKey.publicKey.toString()
+
+  return utils.getAddressFromPublicKey(publicKey)
+}
+
+function generateAddresses(bip32XPublicKey: string, start: ?number, end: ?number): Array<string> {
+  const hdRoot: HDPublicKey = _getPublicHdRoot(bip32XPublicKey)
+  const startIndex: number = start || 0
+  const endIndex: number = end || startIndex
+  const addressesCount: number = endIndex - startIndex
+
+  // generate range from 0 to addressesCount
+  return Array
+    .from(new Array(addressesCount + 1).keys())
+    .map((currentIndex: number): string => generateAddress(hdRoot, startIndex + currentIndex))
+}
+
+/**
+ * TODO: Move this function into jwallet-web
+ */
+function initKeystore(password: string, passwordOptionsUser?: ?PasswordOptionsUser): Keystore {
+  _testPassword(password)
 
   const passwordOptions: PasswordOptions = _getPasswordOptions(passwordOptionsUser)
 
@@ -665,181 +373,33 @@ function addPrivateKey(
     salt,
     scryptParams,
     encryptionType,
-    derivedKeyLength,
   }: PasswordOptions = passwordOptions
 
-  const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams, derivedKeyLength)
+  const testPasswordData: string = utils.generateSalt(TEST_PASSWORD_DATA_LENGTH)
+  const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams)
+  const testPasswordDataEnc: EncryptedData = _encryptData(testPasswordData, dKey, encryptionType)
 
-  return updateWallet(wallets, walletId, {
+  return {
+    wallets: [],
     passwordOptions,
-    encrypted: {
-      privateKey: _encryptPrivateKey(privateKey, dKey, encryptionType),
-      mnemonic: null,
-    },
-    customType: 'privateKey',
-    isReadOnly: false,
-  })
+    testPasswordData: testPasswordDataEnc,
+  }
 }
 
-function setWalletName(wallets: Wallets, walletId: string, name: string): Wallets {
-  const wallet: Wallet = getWallet(wallets, walletId)
-
-  if (!name) {
-    throw new Error('New wallet name should not be empty')
-  } else if (wallet.name === name) {
-    throw new Error('New wallet name should not be equal with the old one')
-  }
-
-  _checkWalletUniqueness(wallets, name, 'name')
-
-  return updateWallet(wallets, walletId, { name })
-}
-
-function setAddressIndex(wallets: Wallets, walletId: string, addressIndex: number = 0): Wallets {
-  const { type }: Wallet = getWallet(wallets, walletId)
-
-  _checkMnemonicType(type)
-
-  return updateWallet(wallets, walletId, { addressIndex })
-}
-
-function setDerivationPath(
-  wallets: Wallets,
-  walletId: string,
-  password: string,
-  newDerivationPath: string,
-): Wallets {
-  const {
-    encrypted,
-    passwordOptions,
-    mnemonicOptions,
-    type,
-    isReadOnly,
-  }: Wallet = getWallet(wallets, walletId)
-
-  _checkMnemonicType(type)
-  _checkNotReadOnly(isReadOnly)
-
-  if (!checkDerivationPathValid(newDerivationPath)) {
-    throw new Error('Invalid derivation path')
-  }
-
-  if (!(passwordOptions && mnemonicOptions)) {
-    throw new Error('Invalid wallet')
-  }
-
-  const { derivationPath }: MnemonicOptions = mnemonicOptions
-
-  if (derivationPath && (derivationPath.toLowerCase() === newDerivationPath.toLowerCase())) {
-    throw new Error('Can not set the same derivation path')
-  }
-
-  const {
-    salt,
-    scryptParams,
-    encryptionType,
-    derivedKeyLength,
-  }: PasswordOptions = passwordOptions
-
-  const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams, derivedKeyLength)
-
-  if (!encrypted.mnemonic) {
-    throw new Error('Data to decrypt not found')
-  }
-
-  const mnemonic: string = _decryptData(encrypted.mnemonic, dKey, encryptionType)
-
-  const mnemonicOptionsNew: MnemonicOptions = {
-    ...mnemonicOptions,
-    derivationPath: newDerivationPath,
-  }
-
-  const xpub: string = _getXPubFromMnemonic(mnemonic.trim(), mnemonicOptionsNew)
-
-  _checkWalletUniqueness(wallets, xpub, 'bip32XPublicKey')
-
-  return updateWallet(wallets, walletId, {
-    bip32XPublicKey: xpub,
-    mnemonicOptions: mnemonicOptionsNew,
-  })
-}
-
-function setMnemonicPassphrase(
-  wallets: Wallets,
-  walletId: string,
-  password: string,
-  newPassphrase: string,
-): Wallets {
-  const {
-    encrypted,
-    passwordOptions,
-    mnemonicOptions,
-    type,
-    isReadOnly,
-  }: Wallet = getWallet(wallets, walletId)
-
-  _checkMnemonicType(type)
-  _checkNotReadOnly(isReadOnly)
-
-  if (!(newPassphrase && passwordOptions && mnemonicOptions)) {
-    throw new Error('Invalid wallet')
-  }
-
-  const { passphrase }: MnemonicOptions = mnemonicOptions
-
-  if (passphrase && (passphrase.toLowerCase() === newPassphrase.toLowerCase())) {
-    throw new Error('Can not set the same passphrase')
-  }
-
-  const {
-    salt,
-    scryptParams,
-    encryptionType,
-    derivedKeyLength,
-  }: PasswordOptions = passwordOptions
-
-  const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams, derivedKeyLength)
-
-  if (!encrypted.mnemonic) {
-    throw new Error('Data to decrypt not found')
-  }
-
-  const mnemonic: string = _decryptData(encrypted.mnemonic, dKey, encryptionType)
-
-  const mnemonicOptionsNew: MnemonicOptions = {
-    ...mnemonicOptions,
-    passphrase: newPassphrase,
-  }
-
-  const xpub: string = _getXPubFromMnemonic(mnemonic.trim(), mnemonicOptionsNew)
-
-  _checkWalletUniqueness(wallets, xpub, 'bip32XPublicKey')
-
-  return updateWallet(wallets, walletId, {
-    bip32XPublicKey: xpub,
-    mnemonicOptions: mnemonicOptionsNew,
-  })
-}
-
+/**
+ * TODO: Move this function into jwallet-web
+ */
 function setPassword(
-  wallets: Wallets,
-  walletId: string,
+  keystore: Keystore,
   password: string,
-  passwordNew: string,
+  newPassword: string,
   passwordOptionsUser?: ?PasswordOptionsUser,
-): Wallets {
+): Keystore {
   const {
-    type,
-    encrypted,
-    isReadOnly,
+    wallets,
     passwordOptions,
-  }: Wallet = getWallet(wallets, walletId)
-
-  _checkNotReadOnly(isReadOnly)
-
-  if (!passwordOptions) {
-    throw new Error('Invalid wallet')
-  }
+    testPasswordData,
+  }: Keystore = keystore
 
   const passwordOptionsNew: PasswordOptions = _getPasswordOptions(passwordOptionsUser)
 
@@ -847,310 +407,62 @@ function setPassword(
     password,
     passwordOptions.salt,
     passwordOptions.scryptParams,
-    passwordOptions.derivedKeyLength,
+  )
+
+  const testPasswordDataDec: string = _decryptData(
+    testPasswordData,
+    derivedKey,
+    passwordOptions.encryptionType,
   )
 
   const derivedKeyNew: Uint8Array = _deriveKeyFromPassword(
-    passwordNew,
+    newPassword,
     passwordOptionsNew.salt,
     passwordOptionsNew.scryptParams,
-    passwordOptionsNew.derivedKeyLength,
   )
 
-  if (type === MNEMONIC_TYPE) {
-    if (!encrypted.mnemonic) {
-      throw new Error('Data to decrypt not found')
-    }
+  const testPasswordDataEnc: EncryptedData = _encryptData(
+    testPasswordDataDec,
+    derivedKeyNew,
+    passwordOptionsNew.encryptionType,
+  )
 
-    const mnemonicDec: string = _decryptData(
-      encrypted.mnemonic,
-      derivedKey,
-      passwordOptions.encryptionType,
-    )
-
-    const mnemonicEnc: EncryptedData = _encryptData(
-      mnemonicDec,
-      derivedKeyNew,
-      passwordOptionsNew.encryptionType,
-    )
-
-    return updateWallet(wallets, walletId, {
-      passwordOptions: passwordOptionsNew,
-      encrypted: {
-        mnemonic: mnemonicEnc,
-        privateKey: null,
-      },
-    })
-  } else {
-    if (!encrypted.privateKey) {
-      throw new Error('Data to decrypt not found')
-    }
-
-    const privateKeyDec: string = _decryptPrivateKey(
-      encrypted.privateKey,
-      derivedKey,
-      passwordOptions.encryptionType,
-    )
-
-    const privateKeyEnc: EncryptedData = _encryptPrivateKey(
-      privateKeyDec,
-      derivedKeyNew,
-      passwordOptionsNew.encryptionType,
-    )
-
-    return updateWallet(wallets, walletId, {
-      passwordOptions: passwordOptionsNew,
-      encrypted: {
-        privateKey: privateKeyEnc,
-        mnemonic: null,
-      },
-    })
-  }
-}
-
-function getAddress(wallets: Wallets, walletId: string): ?Address {
-  const {
-    type,
-    address,
-    bip32XPublicKey,
-    addressIndex,
-  }: Wallet = getWallet(wallets, walletId)
-
-  if (type === ADDRESS_TYPE) {
-    return address
-  }
-
-  const indexEnd: number = (addressIndex || 0) + 1
-
-  return !bip32XPublicKey ? null : _generateAddresses(bip32XPublicKey, addressIndex, indexEnd)[0]
-}
-
-function getAddresses(wallets: Wallets, walletId: string, start: number, end: number): ?Addresses {
-  const {
-    type,
-    bip32XPublicKey,
-  }: Wallet = getWallet(wallets, walletId)
-
-  _checkMnemonicType(type)
-
-  if (!bip32XPublicKey) {
-    return null
-  }
-
-  return _generateAddresses(bip32XPublicKey, start, end)
-}
-
-function getPrivateKey(wallets: Wallets, walletId: string, password: string): string {
-  const wallet: Wallet = getWallet(wallets, walletId)
-
-  const {
-    encrypted,
-    passwordOptions,
-    type,
-    isReadOnly,
-  } = wallet
-
-  _checkNotReadOnly(isReadOnly)
-
-  if (!passwordOptions) {
-    throw new Error('Invalid wallet')
-  }
-
-  const {
-    salt,
-    scryptParams,
-    encryptionType,
-    derivedKeyLength,
-  }: PasswordOptions = passwordOptions
-
-  const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams, derivedKeyLength)
-
-  if (type === MNEMONIC_TYPE) {
-    if (!encrypted.mnemonic) {
-      throw new Error('Data to decrypt not found')
-    }
-
-    const privateKey: string = _getPrivateKeyFromMnemonic(wallet, dKey)
-
-    return utils.add0x(privateKey)
-  } else {
-    if (!encrypted.privateKey) {
-      throw new Error('Data to decrypt not found')
-    }
-
-    const privateKey: string = _decryptPrivateKey(encrypted.privateKey, dKey, encryptionType)
-
-    return utils.add0x(privateKey)
-  }
-}
-
-function getMnemonic(wallets: Wallets, walletId: string, password: string): string {
-  const {
-    encrypted,
-    passwordOptions,
-    type,
-    isReadOnly,
-  }: Wallet = getWallet(wallets, walletId)
-
-  _checkMnemonicType(type)
-  _checkNotReadOnly(isReadOnly)
-
-  if (!passwordOptions) {
-    throw new Error('Invalid wallet')
-  }
-
-  const {
-    salt,
-    scryptParams,
-    encryptionType,
-    derivedKeyLength,
-  }: PasswordOptions = passwordOptions
-
-  const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams, derivedKeyLength)
-
-  if (!encrypted.mnemonic) {
-    throw new Error('Data to decrypt not found')
-  }
-
-  const paddedMnemonic: string = _decryptData(encrypted.mnemonic, dKey, encryptionType)
-
-  return paddedMnemonic.trim()
-}
-
-function getWalletData(
-  wallets: Wallets,
-  walletId: string,
-  password?: string,
-): WalletDecryptedData {
-  const {
-    encrypted,
-    passwordOptions,
-    id,
-    name,
-    type,
-    address,
-    customType,
-    bip32XPublicKey,
-    isReadOnly,
-  }: Wallet = getWallet(wallets, walletId)
-
-  const walletDecryptedData: WalletDecryptedData = {
-    id,
-    name,
-    address: 'n/a',
-    mnemonic: 'n/a',
-    type: customType,
-    privateKey: 'n/a',
-    bip32XPublicKey: 'n/a',
-    readOnly: isReadOnly ? 'yes' : 'no',
-  }
-
-  if (type === MNEMONIC_TYPE) {
-    if (isReadOnly) {
-      return {
-        ...walletDecryptedData,
-        bip32XPublicKey: bip32XPublicKey || walletDecryptedData.bip32XPublicKey,
-      }
-    }
-
-    if (!(password && passwordOptions)) {
-      throw new Error('Invalid wallet')
-    }
-
-    const {
-      salt,
-      scryptParams,
-      encryptionType,
-      derivedKeyLength,
-    }: PasswordOptions = passwordOptions
-
-    const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams, derivedKeyLength)
-
-    if (!encrypted.mnemonic) {
-      throw new Error('Data to decrypt not found')
-    }
-
-    return {
-      ...walletDecryptedData,
-      bip32XPublicKey: bip32XPublicKey || walletDecryptedData.bip32XPublicKey,
-      mnemonic: _decryptData(encrypted.mnemonic, dKey, encryptionType).trim(),
-    }
-  } else {
-    if (isReadOnly) {
-      return {
-        ...walletDecryptedData,
-        address: address || walletDecryptedData.address,
-      }
-    }
-
-    if (!(password && passwordOptions)) {
-      throw new Error('Invalid wallet')
-    }
-
-    const {
-      salt,
-      scryptParams,
-      encryptionType,
-      derivedKeyLength,
-    }: PasswordOptions = passwordOptions
-
-    const dKey: Uint8Array = _deriveKeyFromPassword(password, salt, scryptParams, derivedKeyLength)
-
-    if (!encrypted.privateKey) {
-      throw new Error('Data to decrypt not found')
-    }
-
-    return {
-      ...walletDecryptedData,
-      address: address || walletDecryptedData.address,
-      privateKey: _decryptPrivateKey(encrypted.privateKey, dKey, encryptionType),
-    }
-  }
-}
-
-function serialize(wallets: Wallets): string {
-  return JSON.stringify({
+  const walletsReEnc: Wallets = _reEncryptWallets(
     wallets,
-    version: CURRENT_VERSION,
-  })
-}
+    derivedKey,
+    derivedKeyNew,
+    passwordOptions.encryptionType,
+    passwordOptionsNew.encryptionType,
+  )
 
-function deserialize(backupData: string): {
-  wallets: Wallets,
-  version: string,
-} {
-  try {
-    return JSON.parse(backupData)
-  } catch (err) {
-    throw new Error('Failed to parse backup data')
+  return {
+    wallets: walletsReEnc,
+    passwordOptions: passwordOptionsNew,
+    testPasswordData: testPasswordDataEnc,
   }
 }
 
 export default {
-  serialize,
-  getWallet,
-  getAddress,
-  deserialize,
-  getMnemonic,
   setPassword,
-  addMnemonic,
-  getAddresses,
-  removeWallet,
-  createWallet,
-  addPrivateKey,
-  setWalletName,
-  getPrivateKey,
-  getWalletData,
-  setAddressIndex,
-  setDerivationPath,
-  setMnemonicPassphrase,
-  // utils
+  initKeystore,
   testPassword,
+  generateAddress,
+  encryptMnemonic,
+  decryptMnemonic,
   generateMnemonic,
+  generateAddresses,
+  encryptPrivateKey,
+  decryptPrivateKey,
   checkAddressValid,
   checkMnemonicValid,
+  getXPubFromMnemonic,
   checkPrivateKeyValid,
+  checkWalletUniqueness,
+  getAddressFromPrivateKey,
   checkDerivationPathValid,
+  checkWalletIsNotReadOnly,
   checkBip32XPublicKeyValid,
   checkChecksumAddressValid,
+  checkWalletIsMnemonicType,
+  getPrivateKeyFromMnemonic,
 }

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -49,8 +49,12 @@ export {
   checkBip32XPublicKeyValid,
 }
 
+export function generateSalt(byteCount: number): string {
+  return utils.generateSalt(byteCount)
+}
+
 export function getPasswordOptions(options: ?PasswordOptionsUser): PasswordOptions {
-  const salt: string = utils.generateSalt(DEFAULT_SALT_BYTES_COUNT)
+  const salt: string = generateSalt(DEFAULT_SALT_BYTES_COUNT)
 
   return !options
     ? {

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -63,13 +63,11 @@ export function getPasswordOptions(options: ?PasswordOptionsUser): PasswordOptio
   return !options
     ? {
       salt,
-      passwordHint: null,
       scryptParams: DEFAULT_SCRYPT_PARAMS,
       encryptionType: DEFAULT_ENCRYPTION_TYPE,
     }
     : {
       salt,
-      passwordHint: options.passwordHint,
       scryptParams: options.scryptParams || DEFAULT_SCRYPT_PARAMS,
       encryptionType: options.encryptionType || DEFAULT_ENCRYPTION_TYPE,
     }

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -53,6 +53,10 @@ export function generateSalt(byteCount: number): string {
   return utils.generateSalt(byteCount)
 }
 
+export function leftPadString(stringToPad: string, padChar: string, totalLength: number) {
+  return utils.leftPadString(stringToPad, padChar, totalLength)
+}
+
 export function getPasswordOptions(options: ?PasswordOptionsUser): PasswordOptions {
   const salt: string = generateSalt(DEFAULT_SALT_BYTES_COUNT)
 
@@ -185,7 +189,7 @@ export function encryptMnemonic(
   password: string,
   passwordOptionsUser?: ?PasswordOptionsUser,
 ): EncryptedData {
-  const mnemonicPad: string = utils.leftPadString(mnemonic, ' ', PADDED_MNEMONIC_LENGTH)
+  const mnemonicPad: string = leftPadString(mnemonic, ' ', PADDED_MNEMONIC_LENGTH)
   const passwordOptions: PasswordOptions = getPasswordOptions(passwordOptionsUser)
 
   const {

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,7 +43,7 @@ export function add0x(data: string): string {
   return `0x${data}`
 }
 
-function getChecksum(address: string): string {
+export function getChecksum(address: string): string {
   const addressLowerCase: string = strip0x(address).toLowerCase()
   const hash: string = cryptoJS.SHA3(addressLowerCase, { outputLength: 256 }).toString(ENCODER)
 


### PR DESCRIPTION
Список затронутых задач в этом pr:
1) JWWEB-73 Добавлена поддержка passphrase/network для `mnemonic` кошельков
2) JWWEB-64 Добавлена возможность смены типа кошелька `read only` -> `full access`
3) JWWEB-75 Изменена политика шифрования кошельков (один пароль для всего)
4) JWWEB-34 & JWWEB-79 Интеграция https://github.com/dropbox/zxcvbn

- Сильно изменено API библиотеки в связи с подготовкой миграции `jwallet-web` на `redux-persist` (для перманентного хранения данных). Ранее структура кошельков формировалась внутри этой библиотеки, что не приемлемо для миграций внутри `jwallet-web`, так как появляются сложности с контролем версии сторонней (данной) библиотеки, а соответственно невозможность выполнить миграцию исключительно внутри `jwallet-web`
- Выключены тесты, в связи с предыдущим пунктом
- Документация находится в устаревшем варианте
- Предлагается постепенно переместить код данной библиотеки внутрь `jwallet-web`, так как в данном виде не имеет смысла использовать ее изолированно, как это происходило ранее

Скомпилированный `es2015` код был добавлен в репозиторий для поддержки `CRA` с `react-scripts`<2 версии (проблема, описываемая здесь https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify)
